### PR TITLE
merge payment info feature and add show payment info flag from settings

### DIFF
--- a/src/app/iterative_planning/components/iteration-step-card/iteration-step-card.component.html
+++ b/src/app/iterative_planning/components/iteration-step-card/iteration-step-card.component.html
@@ -20,11 +20,34 @@
         <span class="property-value" *isProject>{{ step()?.softGoals?.length }}</span>
       </div>
 
-      <div class="utility">
+      <div class="utility-group" *isDemo>
+
+        <div class="utility">
+          <mat-icon>workspace_premium</mat-icon>
+          <div class="utility-value-container">
+            <span class="value">{{ (currentUtility() | default : '-') + '/' + maxOverallUtility() }}</span>
+            <span class="label">Utility</span>
+          </div>
+        </div>
+
+        <!-- The following block SHOWS THE REWARD ASSOCIATED WITH EACH STEP. It has been DISABLED
+        because it might confuse users into thinking that the cost is cumulative rather than a
+        maximum.  -->
+        <div class="utility" *false>
+          <mat-icon>diamond</mat-icon>
+          <div class="utility-value-container">
+            <span class="value">{{ (computeCurrentPayment() | currency:'GBP':'symbol') }}</span>
+            <span class="label">Bonus Reward</span>
+          </div>
+        </div>
+
+      </div>
+
+
+      <div class="utility" *isProject>
         <mat-icon>workspace_premium</mat-icon>
         <div class="utility-value-container">
-          <span class="value" *isProject>{{ step() | stepValue : planProperties() | default : '-/-'}}</span>
-          <span class="value" *isDemo>{{ (step() | stepValue : planProperties() | default : '-') + '/' + maxOverallUtility() }}</span>
+          <span class="value">{{ step() | stepValue : planProperties() | default : '-/-'}}</span>
           <span class="label">Utility</span>
         </div>
       </div>

--- a/src/app/iterative_planning/components/iteration-step-card/iteration-step-card.component.scss
+++ b/src/app/iterative_planning/components/iteration-step-card/iteration-step-card.component.scss
@@ -34,6 +34,12 @@
   }
 }
 
+.utility-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .utility {
   display: grid;
   justify-content: center;

--- a/src/app/iterative_planning/components/iteration-step-card/iteration-step-card.component.ts
+++ b/src/app/iterative_planning/components/iteration-step-card/iteration-step-card.component.ts
@@ -20,23 +20,27 @@ import { DemoDirective } from '../../directives/isDemo.directive';
 import { Store } from '@ngrx/store';
 import { selectIterativePlanningLoadingFinished } from '../../state/iterative-planning.selector';
 
+import { CommonModule } from '@angular/common';
+import { MonetaryRewardEvaluatorService } from '../../service/monetary-reward-evaluator';
+
 @Component({
     selector: 'app-iteration-step-card',
     imports: [
-      MatCardModule, 
-      MatChipsModule, 
-      StepStatusNamePipe, 
-      MatIconModule, 
-      LabelModule, 
-      StepValuePipe, 
-      DefaultPipe, 
-      MatButtonModule, 
-      RouterLink, 
-      MatTooltipModule, 
+      MatCardModule,
+      MatChipsModule,
+      StepStatusNamePipe,
+      MatIconModule,
+      LabelModule,
+      StepValuePipe,
+      DefaultPipe,
+      MatButtonModule,
+      RouterLink,
+      MatTooltipModule,
       StepStatusColorPipe,
       MatProgressBarModule,
       ProjectDirective,
-      DemoDirective
+      DemoDirective,
+      CommonModule
     ],
     templateUrl: './iteration-step-card.component.html',
     styleUrl: './iteration-step-card.component.scss'
@@ -44,19 +48,23 @@ import { selectIterativePlanningLoadingFinished } from '../../state/iterative-pl
 export class IterationStepCardComponent {
 
   store = inject(Store);
+  rewardEvaluator = inject(MonetaryRewardEvaluatorService);
+  stepValuePipe = inject(StepValuePipe);
 
   step = input.required<IterationStep | null>();
   planProperties = input.required<Record<string, PlanProperty> | null>();
 
   anabelCreationInterface = this.store.select(selectIterativePlanningLoadingFinished);
 
-  planComputationRunning = computed(() => 
+  planComputationRunning = computed(() =>
     ! this.step()?.plan ||
-    this.step()?.plan?.status == PlanRunStatus.PENDING || 
+    this.step()?.plan?.status == PlanRunStatus.PENDING ||
     this.step()?.plan?.status == PlanRunStatus.RUNNING
   )
 
   maxOverallUtility = input.required<number>();
+  minPayment = input<number>();
+  maxPayment = input<number>();
 
   fork = output<void>();
   cancel = output<void>();
@@ -68,4 +76,24 @@ export class IterationStepCardComponent {
   onCancel(): void {
     this.cancel.emit();
   }
+
+  currentUtility(): number | undefined {
+    return this.stepValuePipe.transform(this.step(), this.planProperties());
+  }
+
+  computeCurrentUtilityProportion(): number {
+    return this.rewardEvaluator.computeUtilityProportion(
+      this.currentUtility(),
+      this.maxOverallUtility()
+    );
+  }
+
+  computeCurrentPayment(): number {
+    return this.rewardEvaluator.computePayment(
+      this.computeCurrentUtilityProportion(),
+      (this.minPayment() ?? 0),
+      (this.maxPayment() ?? 0)
+    );
+  }
+
 }

--- a/src/app/iterative_planning/components/iteration-step-hero/iteration-step-hero.component.html
+++ b/src/app/iterative_planning/components/iteration-step-hero/iteration-step-hero.component.html
@@ -38,11 +38,33 @@
         </button>
       </div>
 
-      <div class="utility">
+
+      <div class="utility-group" *isDemo>
+        <div class="utility">
+          <mat-icon>workspace_premium</mat-icon>
+          <div class="utility-value-container">
+            <span class="value" *isDemo>{{ (currentUtility() | default : '-') + '/' + maxOverallUtility() }}</span>
+            <span class="label">Utility</span>
+          </div>
+        </div>
+
+        @if(showPaymentInfo()){
+        <div class="utility">
+          <mat-icon>diamond</mat-icon>
+          <div class="utility-value-container">
+            <span class="value">{{ (computeCurrentPayment() | currency:'GBP':'symbol':'1.0-0') + '/' + (maxPayment() | currency:'GBP':'symbol':'1.0-0') }}</span>
+            <span class="label">Bonus Reward</span>
+          </div>
+        </div>
+        }
+      </div>
+      
+
+
+      <div class="utility" *isProject>
         <mat-icon>workspace_premium</mat-icon>
         <div class="utility-value-container">
-          <span class="value" *isProject>{{ step() | stepValue : planProperties() | default : '-/-'}}</span>
-          <span class="value" *isDemo>{{ (step() | stepValue : planProperties() | default : '-') + '/' + maxOverallUtility() }}</span>
+          <span class="value">{{ step() | stepValue : planProperties() | default : '-/-'}}</span>
           <span class="label">Utility</span>
         </div>
       </div>

--- a/src/app/iterative_planning/components/iteration-step-hero/iteration-step-hero.component.scss
+++ b/src/app/iterative_planning/components/iteration-step-hero/iteration-step-hero.component.scss
@@ -26,9 +26,16 @@
   justify-content: center;
 }
 
+.utility-group {
+  display: flex;
+  align-items: center;
+  gap: 40px;
+}
+
 .utility {
   display: grid;
   justify-content: center;
+  justify-items: center;
   align-items: end;
 
   mat-icon {

--- a/src/app/iterative_planning/components/iteration-step-hero/iteration-step-hero.component.ts
+++ b/src/app/iterative_planning/components/iteration-step-hero/iteration-step-hero.component.ts
@@ -19,22 +19,26 @@ import { StepValuePipe } from '../../domain/pipe/step-value.pipe';
 import { TaskInformationDialogComponent } from '../../view/task-information-dialog/task-information-dialog.component';
 import { PlanRunStatus } from '../../domain/plan';
 
+import { CommonModule } from '@angular/common';
+import { MonetaryRewardEvaluatorService } from '../../service/monetary-reward-evaluator';
+
 @Component({
     selector: 'app-iteration-step-hero',
     imports: [
-      MatCardModule, 
-      MatChipsModule, 
-      StepStatusNamePipe, 
-      MatIconModule, 
-      LabelModule, 
-      StepValuePipe, 
-      DefaultPipe, 
-      MatButtonModule, 
-      MatTooltipModule, 
+      MatCardModule,
+      MatChipsModule,
+      StepStatusNamePipe,
+      MatIconModule,
+      LabelModule,
+      StepValuePipe,
+      DefaultPipe,
+      MatButtonModule,
+      MatTooltipModule,
       StepStatusColorPipe,
-      RouterLink, 
+      RouterLink,
       ProjectDirective,
-      DemoDirective
+      DemoDirective,
+      CommonModule
     ],
     templateUrl: './iteration-step-hero.component.html',
     styleUrl: './iteration-step-hero.component.scss'
@@ -42,15 +46,40 @@ import { PlanRunStatus } from '../../domain/plan';
 export class IterationStepHeroComponent {
 
   dialog = inject(MatDialog);
-  
+  rewardEvaluator = inject(MonetaryRewardEvaluatorService);
+  stepValuePipe = inject(StepValuePipe);
+
   step = input.required<IterationStep | null>();
   planProperties = input.required<Record<string, PlanProperty> | null>();
 
   maxOverallUtility = input.required<number>();
+  showPaymentInfo = input<boolean>(false);
+  minPayment = input<number>();
+  maxPayment = input<number>();
 
   solved = computed(() => this.step()?.plan?.status === PlanRunStatus.SOLVED)
 
   openTaskInfo(){
      this.dialog.open(TaskInformationDialogComponent);
   }
+
+  currentUtility(): number | undefined {
+    return this.stepValuePipe.transform(this.step(), this.planProperties());
+  }
+
+  computeCurrentUtilityProportion(): number {
+    return this.rewardEvaluator.computeUtilityProportion(
+      this.currentUtility(),
+      this.maxOverallUtility()
+    );
+  }
+
+  computeCurrentPayment(): number {
+    return this.rewardEvaluator.computePayment(
+      this.computeCurrentUtilityProportion(),
+      this.minPayment(),
+      this.maxPayment()
+    );
+  }
+
 }

--- a/src/app/iterative_planning/components/steps-list-hero/steps-list-hero.component.html
+++ b/src/app/iterative_planning/components/steps-list-hero/steps-list-hero.component.html
@@ -5,7 +5,7 @@
             <mat-icon>check</mat-icon>
             <span class="property-label">Solvable:</span>
             <span class="property-value">{{ numSolvedSteps() }}</span>
-    
+
             <mat-icon>report</mat-icon>
             <span class="property-label">Unsolvable:</span>
             <span class="property-value">{{ umUnSolvedSteps() }}</span>
@@ -17,15 +17,62 @@
             Show Task Information
           </button>
         </div>
-  
-        <div class="utility">
-          <mat-icon>workspace_premium</mat-icon>
-          <div class="utility-value-container">
-            <span class="value">{{ (currentMaxUtility() ? currentMaxUtility() : '-') + '/' + maxOverallUtility() }}</span>
-            <span class="label">Utility</span>
+
+
+        <div class="utility-group">
+
+          <!-- Utility X / Y -->
+          <div class="utility">
+            <mat-icon>workspace_premium</mat-icon>
+            <div class="utility-value-container">
+              <span class="value">{{ (currentMaxUtility() ? currentMaxUtility() : '-') + '/' + maxOverallUtility() }}</span>
+              <span class="label">Utility</span>
+            </div>
           </div>
+
+          @if(showPaymentInfo()){
+          <!-- Progress bar for utility & reward -->
+          <div class="progress-wrapper">
+            <div class="progress-bar-background">
+              <!-- The progress bar itself -->
+              <div
+                class="progress-bar-fill"
+                [style.width.%]="computeCurrentUtilityProportion() * 100"
+              ></div>
+              <!-- Ticks that indicate where payment transitions are -->
+              <div
+                *ngFor="let marker of markerPayments"
+                class="tick"
+                [style.left.%]="marker * 100"
+              ></div>
+            </div>
+
+            
+              <!-- The number values indicating reward at each transition -->
+              <div class="payment-markers">
+                <div
+                  *ngFor="let marker of markerPayments"
+                  class="marker"
+                  [style.left.%]="marker * 100"
+                >
+                  {{ computePayment(marker) | currency: 'GBP':'symbol':'1.0-0' }}
+                </div>
+              </div>
+          </div>
+          }
+
+          @if(showPaymentInfo()){
+          <!-- Monetary reward X / Y -->
+          <div class="utility">
+            <mat-icon>diamond</mat-icon>
+            <div class="utility-value-container">
+              <span class="value">{{ (computeCurrentPayment() | currency:'GBP':'symbol':'1.0-0') + '/' + (maxPayment() | currency:'GBP':'symbol':'1.0-0') }}</span>
+              <span class="label">Bonus Reward</span>
+            </div>
+          </div>
+          }
+
         </div>
       </div>
     </mat-card-content>
 </mat-card>
-  

--- a/src/app/iterative_planning/components/steps-list-hero/steps-list-hero.component.scss
+++ b/src/app/iterative_planning/components/steps-list-hero/steps-list-hero.component.scss
@@ -1,5 +1,15 @@
 @use '../../../../variables' as vars;
 
+.tick {
+  position: absolute;
+  top: -4px; // make it stick out above the bar
+  height: 18px;
+  width: 2px;
+  background-color: black;
+  transform: translateX(-50%);
+  z-index: 10;
+}
+
 .content {
   padding-top: var(--spacing-100);
 
@@ -26,9 +36,52 @@
   justify-content: center;
 }
 
+.progress-wrapper {
+  min-width: 200px;
+  position: relative;
+}
+
+.progress-bar-background {
+  background-color: #e0e0e0;
+  height: 10px;
+  border-radius: 0px; // use bigger number for rounded edges, e.g., 5px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  background-color: #4caf50;
+  height: 100%;
+  width: 0%;
+  transition: width 0.3s ease;
+}
+
+.payment-markers {
+  position: absolute;
+  top: 14px; // just under the progress bar
+  left: 0;
+  width: 100%;
+  height: 20px;
+}
+
+.marker {
+  position: absolute;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  white-space: nowrap;
+  color: #666;
+}
+
+.utility-group {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 40px;
+}
+
 .utility {
   display: grid;
   justify-content: center;
+  justify-items: center;
   align-items: end;
 
   mat-icon {

--- a/src/app/iterative_planning/components/steps-list-hero/steps-list-hero.component.ts
+++ b/src/app/iterative_planning/components/steps-list-hero/steps-list-hero.component.ts
@@ -9,13 +9,17 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { TaskInformationDialogComponent } from '../../view/task-information-dialog/task-information-dialog.component';
 
+import { CommonModule } from '@angular/common';
+import { MonetaryRewardEvaluatorService } from '../../service/monetary-reward-evaluator';
+
 @Component({
   selector: 'app-steps-list-hero',
   imports: [
     MatCardModule,
     MatIconModule,
     DemoDirective,
-    MatButtonModule
+    MatButtonModule,
+    CommonModule
   ],
   templateUrl: './steps-list-hero.component.html',
   styleUrl: './steps-list-hero.component.scss'
@@ -23,12 +27,21 @@ import { TaskInformationDialogComponent } from '../../view/task-information-dial
 export class StepsListHeroComponent {
 
   dialog = inject(MatDialog);
+  rewardEvaluator = inject(MonetaryRewardEvaluatorService);
 
   planPropertiesMap = input.required<Record<string,PlanProperty>>();
   steps = input.required<IterationStep[]>();
 
   maxOverallUtility = input.required<number>();
   currentMaxUtility = input.required<number>();
+  showPaymentInfo = input<boolean>(false);
+  minPayment = input<number>();
+  maxPayment = input<number>();
+
+  // Put payment markers at these utility proportions
+  //
+  // HACK: hard-coded for now
+  markerPayments = [0.0, 0.5, 0.75, 1.0];
 
   numSolvedSteps = computed(() => this.steps()?.filter(s => s.status === StepStatus.SOLVABLE).length)
   umUnSolvedSteps = computed(() => this.steps()?.filter(s => s.status === StepStatus.UNSOLVABLE).length)
@@ -36,4 +49,28 @@ export class StepsListHeroComponent {
   openTaskInfo(){
    this.dialog.open(TaskInformationDialogComponent);
   }
+
+  computePayment(utility_proportion: number){
+    return this.rewardEvaluator.computePayment(
+      utility_proportion,
+      this.minPayment(),
+      this.maxPayment()
+    );
+  }
+
+  computeCurrentUtilityProportion(): number {
+    return this.rewardEvaluator.computeUtilityProportion(
+      this.currentMaxUtility(),
+      this.maxOverallUtility()
+    );
+  }
+
+  computeCurrentPayment(): number {
+    return this.rewardEvaluator.computePayment(
+      this.computeCurrentUtilityProportion(),
+      this.minPayment(),
+      this.maxPayment()
+    );
+  }
+
 }

--- a/src/app/iterative_planning/domain/pipe/step-value.pipe.ts
+++ b/src/app/iterative_planning/domain/pipe/step-value.pipe.ts
@@ -1,9 +1,10 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, Injectable } from '@angular/core';
 
 import { IterationStep, StepStatus } from '../iteration_step';
 import { PlanProperty } from '../../../shared/domain/plan-property/plan-property';
 import { computeUtility } from '../plan';
 
+@Injectable({ providedIn: 'root' })
 @Pipe({
   name: 'stepValue',
   standalone: true

--- a/src/app/iterative_planning/service/monetary-reward-evaluator.ts
+++ b/src/app/iterative_planning/service/monetary-reward-evaluator.ts
@@ -1,0 +1,97 @@
+import { Injectable } from "@angular/core";
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MonetaryRewardEvaluatorService{
+
+  //
+  // Input:
+  // - the proportion of max **utility**, e.g., 6/12 has proportion 0.5
+  // - min money that's earnable
+  // - max money that's earnable with bonus
+  //
+  // Output:
+  // - the **payment** that is earned with given utility proportion
+
+  //   CAREFUL: the semantic can be either bonus payment or total payment
+  //   - for bonus payment set minMoney = 0 and maxMoney to the max. bonus reward
+  //   - for total payment set minMoney to the base reward and maxMoney to the base + max bonus.
+  //
+  // HACK: the way that utility proportion maps onto monetary-reward proportion is hard coded
+  //
+  computePayment(
+    utilityProportion: number,
+    minMoney: number | undefined,
+    maxMoney: number | undefined
+  ): number {
+
+    //
+    // Handle possible issues with input parameters
+    //
+    // NOTE: the fall-back value is 0, i.e., "you will get no (bonus) money"
+    //
+    if (utilityProportion < 0 || utilityProportion > 1) {
+        // console.error("utilityProportion should be between 0 and 1 (inclusive)");
+        return 0.0;
+    }
+    if (minMoney === undefined || maxMoney === undefined) {
+        // console.error("minMoney and/or maxMoney is undefined");
+        return 0.0;
+    }
+    if (minMoney < 0 || maxMoney < 0 || minMoney > maxMoney) {
+        // console.error("bad values of minMoney and/or maxMoney");
+        return 0.0;
+    }
+
+    const maxBonus = maxMoney - minMoney;
+
+    if (utilityProportion < 0.5) {
+      return minMoney;
+    } else if (utilityProportion < 0.75) {
+      return minMoney + ((1/3) * maxBonus);
+    } else if (utilityProportion < 1.0) {
+      return minMoney + ((2/3) * maxBonus);
+    } else if (utilityProportion == 1.0) {
+      return minMoney + maxBonus;
+    }
+
+    // Catch-all
+    return 0.0;
+  }
+
+  //
+  // Input:
+  // - current attained utility
+  // - max possible utility
+  //
+  // Output:
+  // - a **utility** proportion, e.g., 6/12 has proportion 0.5
+  //
+  computeUtilityProportion(
+    currentUtility: number | undefined,
+    maxUtility: number | undefined
+  ): number {
+
+    //
+    // Handle possible issues with input parameters
+    //
+    // NOTE: the fall-back value is 0.0, i.e., "you have attained 0 utility"
+    //
+    if (currentUtility === undefined || maxUtility === undefined) {
+      // console.error("currentUtility and/or maxUtility is undefined");
+      return 0.0;
+    }
+    if (maxUtility == 0) {
+      return 0.0;
+    }
+    if (currentUtility < 0 || maxUtility < 0 || currentUtility > maxUtility) {
+      // console.error("bad value of currentUtility and/or maxUtility");
+      return 0.0;
+    }
+
+    return currentUtility / maxUtility;
+  }
+
+}

--- a/src/app/iterative_planning/state/iterative-planning.selector.ts
+++ b/src/app/iterative_planning/state/iterative-planning.selector.ts
@@ -34,19 +34,31 @@ export const selectIterativePlanningPropertyTemplates = createSelector(selectSta
 
 // Settings
 
-export const selectIterativePlanningProjectCreationInterfaceType = createSelector(selectState,
-    (state) => state.project?.data?.settings?.interfaces.propertyCreationInterfaceType)
+export const selectSettings = createSelector(selectState,
+    (state) => state.project?.data?.settings)
 
-export const selectIterativePlanningProjectExplanationInterfaceType = createSelector(selectState,
-  (state) => state.project?.data?.settings?.interfaces.explanationInterfaceType)
+export const selectIterativePlanningProjectCreationInterfaceType = createSelector(selectSettings,
+    (settings) => settings?.interfaces.propertyCreationInterfaceType)
+
+export const selectIterativePlanningProjectExplanationInterfaceType = createSelector(selectSettings,
+  (settings) => settings?.interfaces.explanationInterfaceType)
+
+export const selectIterativePlanningShowPaymentInfo = createSelector(selectSettings,
+  (settings) => settings?.userStudy.showPaymentInfo)
+
+export const selectIterativePlanningMinPayment = createSelector(selectSettings,
+  (settings) => settings?.userStudy.paymentInfo.min)
+
+export const selectIterativePlanningMaxPayment = createSelector(selectSettings,
+  (settings) => settings?.userStudy.paymentInfo.max)
 
 // Plan Properties
 
 export const selectIterativePlanningProperties = createSelector(selectState,
     (state) => state.planProperties?.data)
 export const selectIterativePlanningPropertiesList = createSelector(selectState,
-    (state) => state.planProperties.state === LoadingState.Done && state.planProperties?.data !== undefined? 
-    Object.values(state.planProperties?.data) 
+    (state) => state.planProperties.state === LoadingState.Done && state.planProperties?.data !== undefined?
+    Object.values(state.planProperties?.data)
     : null
   )
 
@@ -74,7 +86,7 @@ export const selectIterationStepIds = createSelector(selectIterativePlanningIter
 
 export const selectIterationStepById = memoizeWith(
   (stepId: string) => stepId,
-  (stepId: string) => createSelector(selectIterativePlanningIterationSteps, 
+  (stepId: string) => createSelector(selectIterativePlanningIterationSteps,
     (steps) => steps ? steps.find(({_id}) => _id === stepId) : null
 ));
 export const selectIterativePlanningIterationStepsLoadingState = createSelector(selectState,
@@ -102,7 +114,7 @@ export const selectIterativePlanningCurrentMaxUtility = createSelector(selectSta
     let cmu = undefined;
     if(!state.iterationSteps.data || state.iterationSteps.data.length === 0 || state.planProperties.data == undefined){
       return 0;
-    } 
+    }
     cmu = computeCurrentMaxUtility(state.iterationSteps.data, state.planProperties.data);
     return cmu;
 });
@@ -117,7 +129,7 @@ export const selectIterativePlanningMaxPossibleUtility = createSelector(selectSt
 });
 
 
-// Messages    
+// Messages
 
 const selectAllMessages = createSelector(selectState, ({messages}) => messages);
 export const selectMessages = memoizeWith(

--- a/src/app/iterative_planning/view/step-detail-view/step-detail-view.component.html
+++ b/src/app/iterative_planning/view/step-detail-view/step-detail-view.component.html
@@ -26,9 +26,27 @@
         (click)="createNewIteration(step?._id)"><mat-icon>call_split</mat-icon></button>
     </app-page-title-action>
   </app-page-title>
+
+
+  <app-page-hero *isDemo>
+    <app-steps-list-hero
+      [maxOverallUtility]="maxOverAllUtility$ | async"
+      [currentMaxUtility]="currentMaxUtility$ | async"
+      [showPaymentInfo]="showPaymentInfo$ | async"
+      [minPayment]="minPayment$ | async"
+      [maxPayment]="maxPayment$ | async"
+      [steps]="steps$ | async"
+      [planPropertiesMap]="planProperties$ | async"
+    ></app-steps-list-hero>
+  </app-page-hero>
+
+
   <app-page-hero>
     <app-iteration-step-hero
-      [maxOverallUtility]="maxOverAllUtility$ | async" 
+      [maxOverallUtility]="maxOverAllUtility$ | async"
+      [showPaymentInfo]="showPaymentInfo$ | async"
+      [minPayment]="minPayment$ | async"
+      [maxPayment]="maxPayment$ | async"
       [step]="step$ | async"
       [planProperties]="planProperties$ | async">
     </app-iteration-step-hero>

--- a/src/app/iterative_planning/view/step-detail-view/step-detail-view.component.ts
+++ b/src/app/iterative_planning/view/step-detail-view/step-detail-view.component.ts
@@ -28,6 +28,7 @@ import { PlanProperty } from "../../../shared/domain/plan-property/plan-property
 import { ExplanationChatLlmComponent } from "../../components/explanation-chat-llm/explanation-chat-llm.component";
 import { AvailableQuestion, ExplanationChatComponent } from "../../components/explanation-chat/explanation-chat.component";
 import { IterationStepHeroComponent } from "../../components/iteration-step-hero/iteration-step-hero.component";
+import { StepsListHeroComponent } from '../../components/steps-list-hero/steps-list-hero.component';
 import { UserManualDialogComponent } from "../../components/user-manual-dialog/user-manual-dialog.component";
 import { DemoDirective } from "../../directives/isDemo.directive";
 import { ProjectDirective } from "../../directives/isProject.directive";
@@ -42,7 +43,10 @@ import {
   selectIsExplanationLoading,
   selectIterativePlanningIsIntroTask,
   selectIterativePlanningLoadingFinished,
+  selectIterativePlanningCurrentMaxUtility,
+  selectIterativePlanningMaxPayment,
   selectIterativePlanningMaxPossibleUtility,
+  selectIterativePlanningMinPayment,
   selectIterativePlanningProject,
   selectIterativePlanningProjectExplanationInterfaceType,
   selectIterativePlanningProperties,
@@ -51,6 +55,8 @@ import {
   selectMessages,
   selectPropertyAvailableQuestions,
   selectStepAvailableQuestions,
+  selectIterativePlanningIterationSteps,
+  selectIterativePlanningShowPaymentInfo,
 } from "../../state/iterative-planning.selector";
 import {
   selectEnforcedGoals,
@@ -61,25 +67,26 @@ import { ExplanationChatHybridComponent } from "../../components/explanation-cha
 
 @Component({
     selector: "app-step-detail-view",
-    imports: [
-        AsyncPipe,
-        BreadcrumbModule,
-        EmptyStateModule,
-        ExplanationChatComponent,
-        ExplanationChatLlmComponent,
-        ExplanationChatHybridComponent,
-        IterationStepHeroComponent,
-        MatButtonModule,
-        MatIconModule,
-        MatTooltipModule,
-        PageModule,
-        PlanPropertyPanelComponent,
-        RouterLink,
-        MatExpansionModule,
-        ProjectDirective,
-        DemoDirective,
-        MatProgressBarModule
-    ],
+  imports: [
+    AsyncPipe,
+    BreadcrumbModule,
+    EmptyStateModule,
+    ExplanationChatComponent,
+    ExplanationChatLlmComponent,
+    IterationStepHeroComponent,
+    StepsListHeroComponent,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
+    PageModule,
+    PlanPropertyPanelComponent,
+    RouterLink,
+    MatExpansionModule,
+    MatProgressBarModule,
+    ProjectDirective,
+    DemoDirective,
+    ExplanationChatHybridComponent
+  ],
     templateUrl: "./step-detail-view.component.html",
     styleUrl: "./step-detail-view.component.scss"
 })
@@ -101,8 +108,14 @@ export class StepDetailViewComponent {
 
   project$ = this.store.select(selectIterativePlanningProject);
   maxOverAllUtility$ = this.store.select(selectIterativePlanningMaxPossibleUtility);
+  currentMaxUtility$ = this.store.select(selectIterativePlanningCurrentMaxUtility);
+  showPaymentInfo$ = this.store.select(selectIterativePlanningShowPaymentInfo);
+  minPayment$ = this.store.select(selectIterativePlanningMinPayment);
+  maxPayment$ = this.store.select(selectIterativePlanningMaxPayment);
   image$ = this.project$.pipe(map(p => p?.summaryImage));
   instanceInfo$ = this.project$.pipe(map(p => p?.instanceInfo));
+
+  steps$ = this.store.select(selectIterativePlanningIterationSteps);
 
   step$ = this.store.select(selectIterativePlanningSelectedStep);
   stepId$ = this.step$.pipe(map(step => step?._id));

--- a/src/app/iterative_planning/view/steps-list-view/steps-list-view.component.html
+++ b/src/app/iterative_planning/view/steps-list-view/steps-list-view.component.html
@@ -6,7 +6,7 @@
     <app-breadcrumb-item>All Iterations</app-breadcrumb-item>
   </app-breadcrumb>
   <app-page-title>
-    
+
     Plan Iterations
 
     <app-page-title-action>
@@ -22,6 +22,9 @@
     <app-steps-list-hero
       [maxOverallUtility]="maxOverallUtility$ | async"
       [currentMaxUtility]="currentMaxUtility$ | async"
+       [showPaymentInfo]="showPaymentScale$ | async"
+      [minPayment]="minPayment$ | async"
+      [maxPayment]="maxPayment$ | async"
       [steps]="steps$ | async"
       [planPropertiesMap]="planProperties"
     ></app-steps-list-hero>
@@ -29,15 +32,17 @@
 
   <app-page-content>
     <app-page-section-list>
-      
+
       <app-page-section>
         <app-page-section-content>
           <div class="page-grid">
             @for(step of steps$ | async; track step) {
-              <app-iteration-step-card 
-                [step]="step" 
-                [planProperties]="planProperties" 
+              <app-iteration-step-card
+                [step]="step"
+                [planProperties]="planProperties"
                 [maxOverallUtility]="maxOverallUtility$ | async"
+                [minPayment]="minPayment$ | async"
+                [maxPayment]="maxPayment$ | async"
                 (fork)="createNewIteration(step._id)"
                 (cancel)="cancelIterationStep(step._id)">
               </app-iteration-step-card>
@@ -54,7 +59,7 @@
 
           </div>
         </app-page-section-content>
-      </app-page-section> 
+      </app-page-section>
 
     </app-page-section-list>
   </app-page-content>

--- a/src/app/iterative_planning/view/steps-list-view/steps-list-view.component.ts
+++ b/src/app/iterative_planning/view/steps-list-view/steps-list-view.component.ts
@@ -10,7 +10,7 @@ import { PageModule } from 'src/app/shared/components/page/page.module';
 
 import { IterationStepCardComponent } from '../../components/iteration-step-card/iteration-step-card.component';
 import { cancelPlanComputationAndIterationStep, initNewIterationStep } from '../../state/iterative-planning.actions';
-import { selectIterativePlanningCurrentMaxUtility, selectIterativePlanningIterationSteps, selectIterativePlanningIterationStepsLoadingState, selectIterativePlanningLoadingFinished, selectIterativePlanningMaxPossibleUtility, selectIterativePlanningProject, selectIterativePlanningProperties } from '../../state/iterative-planning.selector';
+import { selectIterativePlanningCurrentMaxUtility, selectIterativePlanningIterationSteps, selectIterativePlanningIterationStepsLoadingState, selectIterativePlanningLoadingFinished, selectIterativePlanningMaxPayment, selectIterativePlanningMaxPossibleUtility, selectIterativePlanningMinPayment, selectIterativePlanningProject, selectIterativePlanningProperties, selectIterativePlanningShowPaymentInfo } from '../../state/iterative-planning.selector';
 import { ProjectDirective } from '../../directives/isProject.directive';
 import { DemoDirective } from '../../directives/isDemo.directive';
 import { StepsListHeroComponent } from '../../components/steps-list-hero/steps-list-hero.component';
@@ -59,6 +59,9 @@ export class StepsListViewComponent{
 
   maxOverallUtility$ = this.store.select(selectIterativePlanningMaxPossibleUtility);
   currentMaxUtility$ = this.store.select(selectIterativePlanningCurrentMaxUtility);
+  minPayment$ = this.store.select(selectIterativePlanningMinPayment);
+  maxPayment$ = this.store.select(selectIterativePlanningMaxPayment);
+  showPaymentScale$ = this.store.select(selectIterativePlanningShowPaymentInfo);
 
   createNewIteration(baseStepId?: string) {
     this.store.dispatch(initNewIterationStep({baseStepId}));


### PR DESCRIPTION
I removed the video card and execution step and added the option to turn the payment info of and on with the flag `showPaymentInfo` in the settings. 

The min and max payment are taken from the settings, the step are hard coded.